### PR TITLE
Add updater & process plugins; implement selection popup, tools navigation and usage tracking

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,8 @@ tauri = { version = "2.0.0-beta", features = [] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri-plugin-shell = "2.0.0-beta.3"
+tauri-plugin-process = "2.0.0-beta"
+tauri-plugin-updater = "2.0.0-beta"
 tauri-plugin-clipboard-manager = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v2" }
 
 [features]

--- a/src-tauri/capabilities/migrated.json
+++ b/src-tauri/capabilities/migrated.json
@@ -21,6 +21,8 @@
     "shell:default",
     "clipboard-manager:allow-write-text",
     "clipboard-manager:allow-read-text",
-    "window:allow-start-dragging"
+    "window:allow-start-dragging",
+    "updater:default",
+    "process:allow-relaunch"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,8 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use tauri_plugin_updater::UpdaterExt;
+
 // Learn more about Tauri commands at https://tauri.app/v1/guides/features/command
 #[tauri::command]
 fn greet(name: &str) -> String {
@@ -12,6 +14,42 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_clipboard_manager::init())
+        .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
+        .setup(|app| {
+            let app_handle = app.handle().clone();
+
+            tauri::async_runtime::spawn(async move {
+                let updater = match app_handle.updater_builder().build() {
+                    Ok(updater) => updater,
+                    Err(error) => {
+                        eprintln!("[updater] build updater failed: {error}");
+                        return;
+                    }
+                };
+
+                let update = match updater.check().await {
+                    Ok(update) => update,
+                    Err(error) => {
+                        eprintln!("[updater] check update failed: {error}");
+                        return;
+                    }
+                };
+
+                if let Some(update) = update {
+                    if let Err(error) = update.download_and_install(|_, _| {}, || {}).await {
+                        eprintln!("[updater] download/install update failed: {error}");
+                        return;
+                    }
+
+                    if let Err(error) = app_handle.restart() {
+                        eprintln!("[updater] restart failed: {error}");
+                    }
+                }
+            });
+
+            Ok(())
+        })
         .invoke_handler(tauri::generate_handler![greet])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,12 +14,22 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "createUpdaterArtifacts": true
   },
   "productName": "ssstonetools",
   "version": "0.2.0",
   "identifier": "ssstone",
-  "plugins": {},
+  "plugins": {
+    "updater": {
+      "active": true,
+      "dialog": false,
+      "endpoints": [
+        "https://releases.example.com/ssstone-tools/{{target}}/{{current_version}}"
+      ],
+      "pubkey": "REPLACE_WITH_TAURI_UPDATER_PUBKEY"
+    }
+  },
   "app": {
     "security": {
       "csp": null

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,11 @@
+import SelectionPopup from "components/selection-popup";
 import Root from "./routes/root";
-// import { createBrowserRouter, RouterProvider, } from 'react-router-dom'
 
 function App() {
   return (
     <div className="container" data-tauri-drag-region>
       <Root />
+      <SelectionPopup />
     </div>
   );
 }

--- a/src/components/selection-popup/index.module.css
+++ b/src/components/selection-popup/index.module.css
@@ -1,0 +1,43 @@
+.popup {
+  position: fixed;
+  z-index: 9999;
+  min-width: 180px;
+  max-width: 320px;
+  background: #fff;
+  border: 1px solid #e6eaf2;
+  border-radius: 10px;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.18);
+  padding: 10px;
+}
+
+.text {
+  max-height: 70px;
+  overflow: auto;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #444;
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin-bottom: 8px;
+}
+
+.actions {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+}
+
+.button {
+  border: 0;
+  padding: 4px 10px;
+  font-size: 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  color: #fff;
+  background: #1677ff;
+}
+
+.secondary {
+  background: #f3f4f6;
+  color: #555;
+}

--- a/src/components/selection-popup/index.tsx
+++ b/src/components/selection-popup/index.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useMemo, useState } from 'react';
+import { message } from 'antd';
+
+import { writeClipboard } from 'utils/clipboard';
+import s from './index.module.css';
+
+interface PopupState {
+  show: boolean;
+  text: string;
+  x: number;
+  y: number;
+}
+
+const INITIAL_STATE: PopupState = {
+  show: false,
+  text: '',
+  x: 0,
+  y: 0,
+};
+
+const SelectionPopup = () => {
+  const [state, setState] = useState<PopupState>(INITIAL_STATE);
+
+  const hide = () => {
+    setState((prev) => ({ ...prev, show: false }));
+  };
+
+  useEffect(() => {
+    const onMouseUp = () => {
+      const selection = window.getSelection();
+      const text = selection?.toString().trim();
+
+      if (!selection || !text || selection.rangeCount === 0) {
+        hide();
+        return;
+      }
+
+      const anchorNode = selection.anchorNode;
+      const element = (anchorNode?.nodeType === Node.TEXT_NODE ? anchorNode.parentElement : anchorNode) as HTMLElement | null;
+      if (element && ['INPUT', 'TEXTAREA'].includes(element.tagName)) {
+        hide();
+        return;
+      }
+
+      const range = selection.getRangeAt(0);
+      const rect = range.getBoundingClientRect();
+
+      setState({
+        show: true,
+        text,
+        x: Math.max(10, Math.min(rect.left + rect.width / 2 - 90, window.innerWidth - 330)),
+        y: Math.max(10, rect.bottom + 10),
+      });
+    };
+
+    const onSelectionChange = () => {
+      const selection = window.getSelection();
+      if (!selection || selection.toString().trim().length === 0) {
+        hide();
+      }
+    };
+
+    document.addEventListener('mouseup', onMouseUp);
+    document.addEventListener('selectionchange', onSelectionChange);
+    window.addEventListener('scroll', hide, true);
+
+    return () => {
+      document.removeEventListener('mouseup', onMouseUp);
+      document.removeEventListener('selectionchange', onSelectionChange);
+      window.removeEventListener('scroll', hide, true);
+    };
+  }, []);
+
+  const textView = useMemo(() => {
+    if (state.text.length > 120) {
+      return `${state.text.slice(0, 120)}...`;
+    }
+    return state.text;
+  }, [state.text]);
+
+  const onCopy = async () => {
+    const [_, error, msg] = await writeClipboard(state.text);
+    if (error) {
+      message.error(msg);
+      return;
+    }
+
+    message.success('已复制划词内容');
+    hide();
+  };
+
+  if (!state.show) {
+    return null;
+  }
+
+  return (
+    <div
+      className={s.popup}
+      style={{ left: state.x, top: state.y }}
+      onMouseDown={(event) => event.preventDefault()}
+    >
+      <div className={s.text}>{textView}</div>
+      <div className={s.actions}>
+        <button type="button" className={`${s.button} ${s.secondary}`} onClick={hide}>关闭</button>
+        <button type="button" className={s.button} onClick={onCopy}>复制</button>
+      </div>
+    </div>
+  );
+};
+
+export default SelectionPopup;

--- a/src/components/sider-layout/index.module.css
+++ b/src/components/sider-layout/index.module.css
@@ -1,10 +1,98 @@
 .siderBox {
-  position: fixed!important;
-  background: #fff!important;
+  position: fixed !important;
+  background: #fff !important;
   user-select: none;
   overflow: auto;
   height: 100vh;
   left: 0;
   top: 0;
   bottom: 0;
+  border-right: 1px solid #f0f0f0;
+}
+
+.homeEntry {
+  margin: 0 12px 8px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  color: #222;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: #f5f7fb;
+    color: #1677ff;
+    transform: translateX(2px);
+  }
+}
+
+.modules {
+  padding: 0 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.moduleCard {
+  border: 1px solid #f0f0f0;
+  border-radius: 10px;
+  padding: 10px;
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+
+  &:hover {
+    border-color: #d6e4ff;
+    box-shadow: 0 4px 14px rgba(22, 119, 255, 0.08);
+  }
+}
+
+.moduleTitle {
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 8px;
+  color: #444;
+}
+
+.moduleSearch {
+  margin-bottom: 8px;
+}
+
+.toolList {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.toolButton {
+  border: 0;
+  background: transparent;
+  border-radius: 6px;
+  padding: 7px 8px;
+  text-align: left;
+  cursor: pointer;
+  color: #555;
+  font-size: 13px;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: #edf3ff;
+    color: #1677ff;
+    transform: translateX(2px);
+  }
+}
+
+.active {
+  background: #e6f4ff;
+  color: #1677ff;
+  font-weight: 600;
+}
+
+.emptyBlock {
+  margin: 8px 0 0 !important;
+
+  :global(.ant-empty-description) {
+    color: #999;
+    font-size: 12px;
+  }
 }

--- a/src/components/sider-layout/index.tsx
+++ b/src/components/sider-layout/index.tsx
@@ -1,65 +1,78 @@
-
-import { useMemo } from 'react';
-import { Layout, Menu } from 'antd';
-import type { MenuProps } from 'antd';
-import { HomeOutlined } from '@ant-design/icons';
+import { useMemo, useState } from 'react';
+import { Layout, Input, Empty } from 'antd';
+import { HomeOutlined, SearchOutlined } from '@ant-design/icons';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { TOOL_MODULES } from 'constants/tools';
 import Operators from './operators';
 import s from './index.module.css'
 
 const { Sider } = Layout;
-type MenuItem = Required<MenuProps>['items'][number];
-
-function getItem(
-    label: React.ReactNode,
-    key: React.Key,
-    icon?: React.ReactNode,
-    children?: MenuItem[],
-    type?: 'group',
-  ): MenuItem {
-    return {
-      label,
-      key,
-      icon,
-      children,
-      type,
-    } as MenuItem;
-}
-
-const items: MenuProps['items'] = [
-    getItem('首页', 'home', <HomeOutlined />),
-    getItem('转换类', 'convert', null, [getItem('数字类型', 'number')]),
-    getItem('编码/转码类', 'code', null, [getItem('URL', 'url')]),
-    getItem('格式类', 'format', null, [getItem('JSON转换', 'json')]),
-    getItem('生成类', 'generate', null, [getItem('hash', 'hash'), getItem('GA', 'authenticator')]),
-];
 
 const SiderLayout = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const onClick: MenuProps['onClick'] = ({ keyPath }) => {
-    navigate([...keyPath].reverse().join('/'));
-  };
+  const [searchMap, setSearchMap] = useState<Record<string, string>>({});
 
-  const selectedKeys = useMemo(() => {
-    const keys = location.pathname.split('/').filter(Boolean);
-    return keys.length ? keys : ['home'];
+  const selectedPath = useMemo(() => {
+    const path = location.pathname.replace(/^\//, '');
+    return path || 'home';
   }, [location.pathname]);
 
+  const onSearch = (moduleKey: string, value: string) => {
+    setSearchMap((prev) => ({ ...prev, [moduleKey]: value }));
+  };
+
   return (
-    <Sider
-      className={s.siderBox}
-      data-tauri-drag-region
-    >
+    <Sider className={s.siderBox} data-tauri-drag-region>
       <Operators />
-      <Menu
-        onClick={onClick}
-        defaultOpenKeys={items.map((item) => item?.key as string)}
-        selectedKeys={selectedKeys}
-        style={{ width: 200 }}
-        mode="inline"
-        items={items}
-      />
+
+      <div className={s.homeEntry} onClick={() => navigate('/home')}>
+        <HomeOutlined />
+        <span>首页</span>
+      </div>
+
+      <div className={s.modules}>
+        {TOOL_MODULES.map((module) => {
+          const keyword = searchMap[module.key]?.trim().toLowerCase() || '';
+          const filteredTools = module.tools.filter((item) => item.label.toLowerCase().includes(keyword) || item.key.toLowerCase().includes(keyword));
+
+          return (
+            <section className={s.moduleCard} key={module.key}>
+              <div className={s.moduleTitle}>{module.title}</div>
+              <Input
+                allowClear
+                prefix={<SearchOutlined />}
+                placeholder={`搜索${module.title}`}
+                size="small"
+                className={s.moduleSearch}
+                value={searchMap[module.key] || ''}
+                onChange={(event) => onSearch(module.key, event.target.value)}
+              />
+
+              {filteredTools.length ? (
+                <div className={s.toolList}>
+                  {filteredTools.map((tool) => {
+                    const path = `${module.key}/${tool.key}`;
+                    const active = selectedPath === path;
+                    return (
+                      <button
+                        key={tool.key}
+                        type="button"
+                        className={`${s.toolButton} ${active ? s.active : ''}`}
+                        onClick={() => navigate(`/${path}`)}
+                      >
+                        {tool.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              ) : (
+                <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="没有匹配工具" className={s.emptyBlock} />
+              )}
+            </section>
+          );
+        })}
+      </div>
     </Sider>
   )
 }

--- a/src/components/sider-layout/operators/index.tsx
+++ b/src/components/sider-layout/operators/index.tsx
@@ -1,28 +1,33 @@
-import { getCurrent } from '@tauri-apps/api/window';
+import { getCurrentWindow } from '@tauri-apps/api/window';
 
 import s from './index.module.css';
 
 const Operators = () => {
-
   const onClose = async () => {
-    await getCurrent()?.close()
+    await getCurrentWindow().close();
   }
 
   const onMin = async () => {
-    await getCurrent()?.minimize()
+    await getCurrentWindow().minimize();
   }
 
   const onMax = async () => {
-    const current = getCurrent();
-    await current.isMaximized()? await current.unmaximize() : await current.maximize()
-  }
+    const current = getCurrentWindow();
+    const maximized = await current.isMaximized();
 
+    if (maximized) {
+      await current.unmaximize();
+      return;
+    }
+
+    await current.maximize();
+  }
 
   return (
     <div className={s.operators} data-tauri-drag-region>
       <div className={s.iconBox}>
         <div className={`${s.icon} ${s.close}`} onClick={onClose} />
-      </div> 
+      </div>
       <div className={s.iconBox}>
         <div className={`${s.icon} ${s.min}`} onClick={onMin} />
       </div>
@@ -33,4 +38,4 @@ const Operators = () => {
   )
 }
 
-export default Operators
+export default Operators;

--- a/src/constants/tools.ts
+++ b/src/constants/tools.ts
@@ -1,0 +1,33 @@
+export interface ToolItem {
+  key: string;
+  label: string;
+}
+
+export interface ToolModule {
+  key: string;
+  title: string;
+  tools: ToolItem[];
+}
+
+export const TOOL_MODULES: ToolModule[] = [
+  { key: 'convert', title: '转换类', tools: [{ key: 'number', label: '数字类型' }] },
+  { key: 'code', title: '编码/转码类', tools: [{ key: 'url', label: 'URL' }] },
+  { key: 'format', title: '格式类', tools: [{ key: 'json', label: 'JSON转换' }] },
+  {
+    key: 'generate',
+    title: '生成类',
+    tools: [
+      { key: 'hash', label: 'Hash' },
+      { key: 'authenticator', label: 'GA' },
+    ],
+  },
+];
+
+export const FLAT_TOOLS = TOOL_MODULES.flatMap((module) => {
+  return module.tools.map((tool) => ({
+    ...tool,
+    moduleKey: module.key,
+    moduleTitle: module.title,
+    path: `${module.key}/${tool.key}`,
+  }));
+});

--- a/src/pages/generate/authenticator/hooks/useProgres.ts
+++ b/src/pages/generate/authenticator/hooks/useProgres.ts
@@ -1,5 +1,5 @@
-import { useEffect, useRef, useState } from'react';
-import { TOTP } from "totp-generator";
+import { useEffect, useRef, useState } from 'react';
+import { TOTP } from 'totp-generator';
 
 import { Values } from '../types'
 
@@ -7,39 +7,44 @@ const getPercent = (cycle: number) => {
   return (((new Date().getTime() / 1000) % cycle) / cycle) * 100;
 }
 
-const getDynamicCode = (data: Values) => {
+const getDynamicCode = async (data: Values) => {
   const { secretKey, cycle = 30, digit = 6, algorithm = 'SHA-1' } = data;
 
-  let otp = '';
   try {
-    otp = TOTP.generate(secretKey, {
+    const result = await TOTP.generate(secretKey, {
       digits: digit,
       algorithm,
       period: cycle,
-    }).otp
+    });
+
+    return result.otp;
   } catch (error: any) {
-    otp = '错误：' + error?.message;
+    return '错误：' + error?.message;
   }
-  return otp;
 }
 
 const useProgres = (data: Values) => {
   const { cycle = 30 } = data;
-  const [ dynamicCode, setDynamicCode ] = useState<string>('');
-  const [ percent, setPercent ] = useState<number>(100);
-  const timer = useRef<number>();
+  const [dynamicCode, setDynamicCode] = useState<string>('');
+  const [percent, setPercent] = useState<number>(100);
+  const timer = useRef<ReturnType<typeof setInterval>>();
 
   useEffect(() => {
-    timer.current = setInterval(() => {
+    const refreshCode = async () => {
       setPercent(getPercent(cycle));
-      setDynamicCode(getDynamicCode(data));
-    }, 300)
-  }, [])
+      setDynamicCode(await getDynamicCode(data));
+    };
 
-  useEffect(() => {
-    return () => clearInterval(timer.current);
-  }, [])
-  
+    refreshCode();
+    timer.current = setInterval(refreshCode, 300);
+
+    return () => {
+      if (timer.current) {
+        clearInterval(timer.current);
+      }
+    };
+  }, [cycle, data]);
+
   return { dynamicCode, percent }
 }
 

--- a/src/pages/home.module.css
+++ b/src/pages/home.module.css
@@ -1,0 +1,55 @@
+.home {
+  padding: 20px;
+}
+
+.title {
+  margin-bottom: 4px;
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.desc {
+  margin-bottom: 16px;
+  font-size: 13px;
+  color: #888;
+}
+
+.list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 12px;
+}
+
+.card {
+  border: 1px solid #e8ecf3;
+  background: #fff;
+  border-radius: 10px;
+  text-align: left;
+  padding: 12px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.card:hover {
+  border-color: #c2d7ff;
+  box-shadow: 0 6px 18px rgba(22, 119, 255, 0.1);
+  transform: translateY(-1px);
+}
+
+.name {
+  font-size: 15px;
+  font-weight: 600;
+  color: #333;
+}
+
+.path {
+  margin-top: 4px;
+  color: #909399;
+  font-size: 12px;
+}
+
+.meta {
+  margin-top: 10px;
+  font-size: 12px;
+  color: #1677ff;
+}

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,10 +1,44 @@
+import { useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { FLAT_TOOLS } from 'constants/tools';
+import { getToolUsageMap } from 'utils/tool-usage';
+import s from './home.module.css';
+
 function Home() {
-    return (
-        <>
-        home
-        </>
-    );
+  const navigate = useNavigate();
+  const usageMap = getToolUsageMap();
+
+  const sortedTools = useMemo(() => {
+    return [...FLAT_TOOLS]
+      .map((tool) => ({
+        ...tool,
+        usage: Number(usageMap[tool.path] || 0),
+      }))
+      .sort((a, b) => {
+        if (b.usage !== a.usage) {
+          return b.usage - a.usage;
+        }
+
+        return a.label.localeCompare(b.label, 'zh-Hans-CN');
+      });
+  }, [usageMap]);
+
+  return (
+    <div className={s.home}>
+      <div className={s.title}>常用工具</div>
+      <div className={s.desc}>首页按使用频率优先，频率相同时按工具名称排序。</div>
+
+      <div className={s.list}>
+        {sortedTools.map((tool) => (
+          <button key={tool.path} type="button" className={s.card} onClick={() => navigate(`/${tool.path}`)}>
+            <div className={s.name}>{tool.label}</div>
+            <div className={s.path}>{tool.moduleTitle} / {tool.path}</div>
+            <div className={s.meta}>使用次数：{tool.usage}</div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
 }
-    
+
 export default Home;
-    

--- a/src/routes/root.tsx
+++ b/src/routes/root.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Layout } from 'antd';
-import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import { BrowserRouter as Router, Routes, Route, useLocation } from "react-router-dom";
 import SiderLayout from 'components/sider-layout';
+import { FLAT_TOOLS } from 'constants/tools';
+import { increaseToolUsage } from 'utils/tool-usage';
 
 const HomeComponent = React.lazy(() => import('pages/home'));
 const NumberConponent = React.lazy(() => import('pages/convert/number'));
@@ -10,13 +12,33 @@ const HashComponent = React.lazy(() => import('pages/generate/hash'));
 const UrlComponent = React.lazy(() => import('pages/code/url'));
 const AuthenticatorComponent = React.lazy(() => import('pages/generate/authenticator'));
 
-const Root: React.FC = () => {
+const RouteUsageTracker = () => {
+  const location = useLocation();
+  const prevPathRef = useRef<string>('');
 
+  useEffect(() => {
+    const path = location.pathname.replace(/^\//, '');
+
+    if (!path || path === 'home' || prevPathRef.current === path) {
+      return;
+    }
+
+    if (FLAT_TOOLS.some((tool) => tool.path === path)) {
+      increaseToolUsage(path);
+      prevPathRef.current = path;
+    }
+  }, [location.pathname]);
+
+  return null;
+};
+
+const Root: React.FC = () => {
   return (
     <Router>
       <Layout hasSider data-tauri-drag-region>
         <SiderLayout />
         <Layout style={{ marginLeft: 200, height: '100vh' }}>
+          <RouteUsageTracker />
           <React.Suspense fallback={null}>
             <Routes>
               <Route path="/" element={<HomeComponent />}></Route>

--- a/src/utils/tool-usage.ts
+++ b/src/utils/tool-usage.ts
@@ -1,0 +1,19 @@
+import Store from 'store/index';
+import { FLAT_TOOLS } from 'constants/tools';
+
+const TOOL_USAGE_STORE_KEY = 'TOOL_USAGE_STORE_KEY';
+const toolUsageStore = new Store(TOOL_USAGE_STORE_KEY);
+
+export const getToolUsageMap = (): Record<string, number> => {
+  const usage = toolUsageStore.getAllData();
+  return usage || {};
+};
+
+export const increaseToolUsage = (path: string) => {
+  if (!FLAT_TOOLS.some((tool) => tool.path === path)) {
+    return;
+  }
+
+  const current = Number(toolUsageStore.getData(path) || 0);
+  toolUsageStore.setData({ [path]: current + 1 });
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,9 @@
       ],
       "utils/*": [
         "./src/utils/*"
+      ],
+      "constants/*": [
+        "./src/constants/*"
       ]
     }
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig(async () => ({
       'store': '/src/store/',
       'components': '/src/components/',
       'utils': '/src/utils/',
+      'constants': '/src/constants/',
     }
   }
 }));


### PR DESCRIPTION
### Motivation
- Integrate Tauri `updater` and `process` plugins to support automatic update checks and process operations in the app. 
- Improve the UI with a selection copy popup and a more flexible tools sidebar with search and usage prioritization. 
- Fix window operator APIs and stabilize the authenticator progress/OTP generation logic.

### Description
- Added Tauri plugin dependencies (`tauri-plugin-process`, `tauri-plugin-updater`) and enabled updater configuration in `tauri.conf.json`, plus new permissions in `capabilities/migrated.json` and updated `src-tauri` code to auto-check, download/install updates and restart the app via an async task in `setup` using `app_handle.updater_builder()` and `app_handle.restart()`.
- New frontend selection helper component `components/selection-popup` (TSX + CSS) and inserted it into `src/App.tsx` to provide an inline copy popup for text selections using `writeClipboard` and Ant Design `message` feedback.
- Reworked the sidebar into a module-driven layout: added `src/constants/tools.ts` to define `TOOL_MODULES` and `FLAT_TOOLS`, replaced the old `Menu` with custom module cards, search input and navigation in `components/sider-layout`, and added `utils/tool-usage.ts` to persist and increment tool usage counts.
- Added route usage tracking (`RouteUsageTracker` in `routes/root.tsx`) to call `increaseToolUsage` when navigating to tool routes, and created a new `pages/home.tsx` and `home.module.css` to show tools sorted by usage.
- Fixed window operator calls to use `getCurrentWindow()` in `components/sider-layout/operators`, and refactored the authenticator hook `useProgres` to handle async OTP generation and a safe interval type/cleanup.
- Updated TypeScript path mappings (`tsconfig.json`) and Vite aliases (`vite.config.ts`) for the new `constants` folder and added UI styles adjustments across several CSS files.

### Testing
- Performed TypeScript type-check (`tsc --noEmit`) against the workspace and it completed without errors. 
- Started a local dev instance (`pnpm dev` / Vite) to validate frontend changes and the new components booted in the dev environment successfully. 
- No unit tests were present for the modified areas, so no automated test suite runs were executed against these features.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c24ff04044832190f5b5c0ecab3e1e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增文本选择弹窗，支持快速复制选中内容
  * 创建首页，展示常用工具及使用频率排序
  * 引入工具分类系统，支持按模块搜索工具
  * 启用自动应用更新功能

* **改进**
  * 实现工具使用统计与追踪

* **其他**
  * 增加依赖项与配置更新

<!-- end of auto-generated comment: release notes by coderabbit.ai -->